### PR TITLE
Remove toolbar and add video marking shortcut

### DIFF
--- a/GUI/UI/UI_Main.ui
+++ b/GUI/UI/UI_Main.ui
@@ -253,38 +253,21 @@
      <height>26</height>
     </rect>
    </property>
+   <widget class="QMenu" name="menuFile">
+    <property name="title">
+     <string>文件</string>
+    </property>
+    <addaction name="actionOpen_Video"/>
+    <addaction name="actionOpen_Dir"/>
+    <addaction name="actionChange_Save_Dir"/>
+    <addaction name="actionVideo_marking"/>
+    <addaction name="actionNext_Image"/>
+    <addaction name="actionPrev_Image"/>
+    <addaction name="actionCreate_RectBox"/>
+   </widget>
+   <addaction name="menuFile"/>
   </widget>
   <widget class="QStatusBar" name="statusbar"/>
-  <widget class="QToolBar" name="toolBar">
-   <property name="enabled">
-    <bool>true</bool>
-   </property>
-   <property name="windowTitle">
-    <string>toolBar</string>
-   </property>
-   <property name="iconSize">
-    <size>
-     <width>45</width>
-     <height>45</height>
-    </size>
-   </property>
-   <property name="toolButtonStyle">
-    <enum>Qt::ToolButtonTextUnderIcon</enum>
-   </property>
-   <attribute name="toolBarArea">
-    <enum>LeftToolBarArea</enum>
-   </attribute>
-   <attribute name="toolBarBreak">
-    <bool>false</bool>
-   </attribute>
-   <addaction name="actionOpen_Video"/>
-   <addaction name="actionOpen_Dir"/>
-   <addaction name="actionChange_Save_Dir"/>
-   <addaction name="actionVideo_marking"/>
-   <addaction name="actionNext_Image"/>
-   <addaction name="actionPrev_Image"/>
-   <addaction name="actionCreate_RectBox"/>
-  </widget>
   <action name="actionOpen_Dir">
    <property name="icon">
     <iconset>
@@ -294,7 +277,7 @@
     <string>Open Dir</string>
    </property>
    <property name="shortcut">
-    <string>Ctrl+U</string>
+    <string>E</string>
    </property>
   </action>
   <action name="actionChange_Save_Dir">
@@ -306,7 +289,7 @@
     <string>Change Save Dir</string>
    </property>
    <property name="shortcut">
-    <string>Ctrl+R</string>
+    <string>S</string>
    </property>
   </action>
   <action name="actionNext_Image">
@@ -370,11 +353,14 @@
    <property name="icon">
     <iconset>
      <normaloff>../icons/Video marking.png</normaloff>../icons/Video marking.png</iconset>
-   </property>
-   <property name="text">
-    <string>Video marking</string>
-   </property>
-  </action>
+    </property>
+    <property name="text">
+     <string>Video marking</string>
+    </property>
+    <property name="shortcut">
+     <string>M</string>
+    </property>
+   </action>
  </widget>
  <resources/>
  <connections/>

--- a/GUI/UI/UI_Main.ui
+++ b/GUI/UI/UI_Main.ui
@@ -95,27 +95,6 @@
          <widget class="QWidget" name="layoutWidget">
           <layout class="QVBoxLayout" name="verticalLayout">
            <item>
-            <widget class="QLabel" name="label">
-             <property name="text">
-              <string>选择保存类型</string>
-             </property>
-            </widget>
-           </item>
-           <item>
-            <widget class="QComboBox" name="comboBox">
-             <item>
-              <property name="text">
-               <string>XML</string>
-              </property>
-             </item>
-             <item>
-              <property name="text">
-               <string>YOLO</string>
-              </property>
-             </item>
-            </widget>
-           </item>
-           <item>
             <widget class="QLabel" name="currentImageLabel">
              <property name="text">
               <string>当前图片：-</string>
@@ -265,7 +244,15 @@
     <addaction name="actionPrev_Image"/>
     <addaction name="actionCreate_RectBox"/>
    </widget>
+   <widget class="QMenu" name="menuSaveType">
+    <property name="title">
+     <string>保存类型</string>
+    </property>
+    <addaction name="actionSaveTypeYOLO"/>
+    <addaction name="actionSaveTypeXML"/>
+   </widget>
    <addaction name="menuFile"/>
+   <addaction name="menuSaveType"/>
   </widget>
   <widget class="QStatusBar" name="statusbar"/>
   <action name="actionOpen_Dir">
@@ -353,14 +340,30 @@
    <property name="icon">
     <iconset>
      <normaloff>../icons/Video marking.png</normaloff>../icons/Video marking.png</iconset>
-    </property>
-    <property name="text">
-     <string>Video marking</string>
-    </property>
-    <property name="shortcut">
-     <string>M</string>
-    </property>
-   </action>
+   </property>
+   <property name="text">
+    <string>Video marking</string>
+   </property>
+   <property name="shortcut">
+    <string>M</string>
+   </property>
+  </action>
+  <action name="actionSaveTypeYOLO">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="text">
+    <string>YOLO</string>
+   </property>
+  </action>
+  <action name="actionSaveTypeXML">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="text">
+    <string>XML</string>
+   </property>
+  </action>
  </widget>
  <resources/>
  <connections/>

--- a/GUI/UI_Main.py
+++ b/GUI/UI_Main.py
@@ -106,16 +106,6 @@ class Ui_MainWindow(object):
         MainWindow.setCentralWidget(self.centralwidget)
         self.setSplitterSizes()
 
-        self.label = QtWidgets.QLabel(self.layoutWidget)
-        self.label.setObjectName("label")
-        self.verticalLayout.addWidget(self.label)
-        self.comboBox = QtWidgets.QComboBox(self.layoutWidget)
-        self.comboBox.setObjectName("comboBox")
-        self.comboBox.addItem("")
-        self.comboBox.addItem("")
-        self.comboBox.setFocusPolicy(QtCore.Qt.NoFocus)
-        self.verticalLayout.addWidget(self.comboBox)
-
         self.currentImageLabel = QtWidgets.QLabel(self.layoutWidget)
         self.currentImageLabel.setObjectName("currentImageLabel")
         self.currentImageLabel.setWordWrap(True)
@@ -203,6 +193,8 @@ class Ui_MainWindow(object):
         self.menubar.setObjectName("menubar")
         self.menuFile = QtWidgets.QMenu(self.menubar)
         self.menuFile.setObjectName("menuFile")
+        self.menuSaveType = QtWidgets.QMenu(self.menubar)
+        self.menuSaveType.setObjectName("menuSaveType")
         MainWindow.setMenuBar(self.menubar)
         self.statusbar = QtWidgets.QStatusBar(MainWindow)
         self.statusbar.setObjectName("statusbar")
@@ -256,6 +248,13 @@ class Ui_MainWindow(object):
 
         self.actionOpen_Video.triggered.connect(self.disableLabel4)
 
+        self.actionSaveTypeYOLO = QtWidgets.QAction(MainWindow)
+        self.actionSaveTypeYOLO.setCheckable(True)
+        self.actionSaveTypeYOLO.setObjectName("actionSaveTypeYOLO")
+        self.actionSaveTypeXML = QtWidgets.QAction(MainWindow)
+        self.actionSaveTypeXML.setCheckable(True)
+        self.actionSaveTypeXML.setObjectName("actionSaveTypeXML")
+
         self.menuFile.addAction(self.actionOpen_Video)
         self.menuFile.addAction(self.actionOpen_Dir)
         self.menuFile.addAction(self.actionChange_Save_Dir)
@@ -263,7 +262,10 @@ class Ui_MainWindow(object):
         self.menuFile.addAction(self.actionNext_Image)
         self.menuFile.addAction(self.actionPrev_Image)
         self.menuFile.addAction(self.actionCreate_RectBox)
+        self.menuSaveType.addAction(self.actionSaveTypeYOLO)
+        self.menuSaveType.addAction(self.actionSaveTypeXML)
         self.menubar.addAction(self.menuFile.menuAction())
+        self.menubar.addAction(self.menuSaveType.menuAction())
 
 
         self.retranslateUi(MainWindow)
@@ -303,9 +305,6 @@ class Ui_MainWindow(object):
     def retranslateUi(self, MainWindow):
         _translate = QtCore.QCoreApplication.translate
         MainWindow.setWindowTitle(_translate("MainWindow", "Auto Yolo Labeler"))
-        self.label.setText(_translate("MainWindow", "保存类型"))
-        self.comboBox.setItemText(1, _translate("MainWindow", "XML"))
-        self.comboBox.setItemText(0, _translate("MainWindow", "YOLO"))
         self.currentImageLabel.setText(_translate("MainWindow", ""))
         self.label_2.setText(_translate("MainWindow", "标签"))
         self.label_5.setText(_translate("MainWindow", "视频："))
@@ -317,6 +316,7 @@ class Ui_MainWindow(object):
         self.label_video_marking.setText(_translate("MainWindow", "视频打标"))
         self.pushButton_start_marking.setText(_translate("MainWindow", "目标跟踪"))
         self.menuFile.setTitle(_translate("MainWindow", "文件"))
+        self.menuSaveType.setTitle(_translate("MainWindow", "保存类型"))
         self.actionOpen_Dir.setText(_translate("MainWindow", "Open Dir"))
         self.actionOpen_Dir.setShortcut(_translate("MainWindow", "E"))
         self.actionChange_Save_Dir.setText(_translate("MainWindow", "Change Save Dir"))
@@ -331,4 +331,6 @@ class Ui_MainWindow(object):
         self.actionOpen_Video.setShortcut(_translate("MainWindow", "V"))
         self.actionVideo_marking.setText(_translate("MainWindow", "Video marking"))
         self.actionVideo_marking.setShortcut(_translate("MainWindow", "M"))
+        self.actionSaveTypeYOLO.setText(_translate("MainWindow", "YOLO"))
+        self.actionSaveTypeXML.setText(_translate("MainWindow", "XML"))
 

--- a/GUI/UI_Main.py
+++ b/GUI/UI_Main.py
@@ -201,16 +201,12 @@ class Ui_MainWindow(object):
         self.menubar = QtWidgets.QMenuBar(MainWindow)
         self.menubar.setGeometry(QtCore.QRect(0, 0, 1618, 26))
         self.menubar.setObjectName("menubar")
+        self.menuFile = QtWidgets.QMenu(self.menubar)
+        self.menuFile.setObjectName("menuFile")
         MainWindow.setMenuBar(self.menubar)
         self.statusbar = QtWidgets.QStatusBar(MainWindow)
         self.statusbar.setObjectName("statusbar")
         MainWindow.setStatusBar(self.statusbar)
-        self.toolBar = QtWidgets.QToolBar(MainWindow)
-        self.toolBar.setEnabled(True)
-        self.toolBar.setIconSize(QtCore.QSize(45, 45))
-        self.toolBar.setToolButtonStyle(QtCore.Qt.ToolButtonTextUnderIcon)
-        self.toolBar.setObjectName("toolBar")
-        MainWindow.addToolBar(QtCore.Qt.LeftToolBarArea, self.toolBar)
         self.actionOpen_Dir = QtWidgets.QAction(MainWindow)
         icon1 = QtGui.QIcon()
         icon1.addPixmap(QtGui.QPixmap("GUI/icons/open.png"), QtGui.QIcon.Normal, QtGui.QIcon.Off)
@@ -255,19 +251,20 @@ class Ui_MainWindow(object):
         icon6.addPixmap(QtGui.QPixmap("GUI/icons/video.png"), QtGui.QIcon.Normal, QtGui.QIcon.Off)
         self.actionOpen_Video.setIcon(icon6)
         self.actionOpen_Video.setObjectName("actionOpen_Video")
-        
+
 
 
         self.actionOpen_Video.triggered.connect(self.disableLabel4)
 
-        self.toolBar.addAction(self.actionOpen_Video)
-        self.toolBar.addAction(self.actionOpen_Dir)
-        self.toolBar.addAction(self.actionChange_Save_Dir)
-        self.toolBar.addAction(self.actionVideo_marking)
-        self.toolBar.addAction(self.actionNext_Image)
-        self.toolBar.addAction(self.actionPrev_Image)
-        self.toolBar.addAction(self.actionCreate_RectBox)
-        
+        self.menuFile.addAction(self.actionOpen_Video)
+        self.menuFile.addAction(self.actionOpen_Dir)
+        self.menuFile.addAction(self.actionChange_Save_Dir)
+        self.menuFile.addAction(self.actionVideo_marking)
+        self.menuFile.addAction(self.actionNext_Image)
+        self.menuFile.addAction(self.actionPrev_Image)
+        self.menuFile.addAction(self.actionCreate_RectBox)
+        self.menubar.addAction(self.menuFile.menuAction())
+
 
         self.retranslateUi(MainWindow)
         QtCore.QMetaObject.connectSlotsByName(MainWindow)
@@ -319,7 +316,7 @@ class Ui_MainWindow(object):
         self.pushButton_4.setText(_translate("MainWindow", "重新播放"))
         self.label_video_marking.setText(_translate("MainWindow", "视频打标"))
         self.pushButton_start_marking.setText(_translate("MainWindow", "目标跟踪"))
-        self.toolBar.setWindowTitle(_translate("MainWindow", "toolBar"))
+        self.menuFile.setTitle(_translate("MainWindow", "文件"))
         self.actionOpen_Dir.setText(_translate("MainWindow", "Open Dir"))
         self.actionOpen_Dir.setShortcut(_translate("MainWindow", "E"))
         self.actionChange_Save_Dir.setText(_translate("MainWindow", "Change Save Dir"))
@@ -333,4 +330,5 @@ class Ui_MainWindow(object):
         self.actionOpen_Video.setText(_translate("MainWindow", "Open Video"))
         self.actionOpen_Video.setShortcut(_translate("MainWindow", "V"))
         self.actionVideo_marking.setText(_translate("MainWindow", "Video marking"))
+        self.actionVideo_marking.setShortcut(_translate("MainWindow", "M"))
 

--- a/GUI/main.py
+++ b/GUI/main.py
@@ -95,8 +95,20 @@ class MainFunc(QMainWindow):
 
         self.timer_camera = QTimer()
 
-        self.annotation_format = self.ui.comboBox.currentText().strip().upper() or "XML"
-        self.ui.comboBox.currentTextChanged.connect(self.on_annotation_format_changed)
+        self.annotation_format_actions = {
+            "YOLO": self.ui.actionSaveTypeYOLO,
+            "XML": self.ui.actionSaveTypeXML,
+        }
+        self.save_type_action_group = QtWidgets.QActionGroup(self)
+        self.save_type_action_group.setExclusive(True)
+        for fmt, action in self.annotation_format_actions.items():
+            action.setCheckable(True)
+            action.setData(fmt)
+            self.save_type_action_group.addAction(action)
+            action.triggered.connect(lambda checked, fmt=fmt: self.on_save_type_triggered(fmt, checked))
+
+        self.annotation_format = None
+        self.on_annotation_format_changed("YOLO")
         self.ui.currentImageLabel.setText("Path")
 
         self.ui.actionOpen_Dir.triggered.connect(self.get_dir)
@@ -750,8 +762,21 @@ class MainFunc(QMainWindow):
         self.ui.listWidget.addItem("检测打标完成！")
         print("检测打标完成！")
 
+    def on_save_type_triggered(self, fmt, checked):
+        if checked:
+            self.on_annotation_format_changed(fmt)
+
     def on_annotation_format_changed(self, text):
-        self.annotation_format = text.strip().upper() or "XML"
+        fmt = (text or "").strip().upper() or "XML"
+        if fmt == self.annotation_format:
+            return
+
+        self.annotation_format = fmt
+        for action_fmt, action in self.annotation_format_actions.items():
+            block = action.blockSignals(True)
+            action.setChecked(action_fmt == fmt)
+            action.blockSignals(block)
+
         self.Exists_Labels_And_Boxs()
 
     def save_annotation_files(self, image_path, image_name, size, labels):

--- a/GUI/main.py
+++ b/GUI/main.py
@@ -85,6 +85,8 @@ class MainFunc(QMainWindow):
         self.labels = []
         self.clicked_save = []
         self.paint_save = []
+        self.label_boxes_by_row = []
+        self.list_labels = []
         self.flag = False
         self.save = True
         self.cap = None
@@ -147,12 +149,96 @@ class MainFunc(QMainWindow):
             self.ui.actionPrev_Image.setEnabled(state)
             self.ui.actionNext_Image.setEnabled(state)
             self.ui.actionCreate_RectBox.setEnabled(state)
+
+    def clear_label_list(self):
+        self.ui.listWidget.clear()
+        self.label_boxes_by_row = []
+
+    @staticmethod
+    def _normalized_box(x1, y1, x2, y2):
+        return [min(x1, x2), min(y1, y2), max(x1, x2), max(y1, y2)]
+
+    def _remove_box_from_collections(self, box):
+        for collection in (self.clicked_save, self.paint_save):
+            for idx, existing in enumerate(collection):
+                if existing == box:
+                    collection.pop(idx)
+                    return
+
+    def _persist_labels_after_edit(self):
+        if not self.save_path or not self.image_name:
+            return
+
+        base_path = Path(self.save_path) / self.image_name
+        if not self.labels:
+            xml_path = base_path.with_suffix(".xml")
+            txt_path = base_path.with_suffix(".txt")
+            if xml_path.exists():
+                xml_path.unlink()
+            if txt_path.exists():
+                txt_path.unlink()
+            return
+
+        if self.img_width and self.img_height:
+            size = [self.img_width, self.img_height, 3]
+            self.save_annotation_files(self.image_path, self.image_name, size, self.labels)
+
+    def remove_selected_labels(self):
+        selected_indexes = self.ui.listWidget.selectedIndexes()
+        if not selected_indexes or not self.labels:
+            return False
+
+        rows = sorted({index.row() for index in selected_indexes}, reverse=True)
+        removed = False
+        for row in rows:
+            if row >= len(self.labels):
+                continue
+
+            removed = True
+            self.ui.listWidget.takeItem(row)
+            del self.labels[row]
+            if self.list_labels and row < len(self.list_labels):
+                del self.list_labels[row]
+
+            if row < len(self.label_boxes_by_row):
+                box = self.label_boxes_by_row.pop(row)
+                self._remove_box_from_collections(box)
+
+        if removed:
+            if self.img_path:
+                self.Show_Exists()
+            self._persist_labels_after_edit()
+
+        return removed
+
+    def clear_all_annotations(self):
+        self.clicked_event = False
+        self.paint_event = False
+        self.save = True
+        self.clear_label_list()
+        self.list_labels = []
+        self.clicked_save = []
+        self.paint_save = []
+        self.labels = []
+        if self.img_path:
+            self.show_qt(self.img_path)
+        self.ui.label_4.mousePressEvent = self.mouse_press_event
+        self.ui.label_4.setCursor(Qt.ArrowCursor)
+
+        base_path = Path(self.save_path) / self.image_name if self.save_path and self.image_name else None
+        if base_path:
+            xml_path = base_path.with_suffix(".xml")
+            txt_path = base_path.with_suffix(".txt")
+            if xml_path.exists():
+                xml_path.unlink()
+            if txt_path.exists():
+                txt_path.unlink()
             
     def get_dir(self):
-        self.ui.listWidget.clear()
+        self.clear_label_list()
         if self.cap:
             self.timer_camera.stop()
-            self.ui.listWidget.clear()  # 清空listWidget
+            self.clear_label_list()  # 清空listWidget
         self.directory = QtWidgets.QFileDialog.getExistingDirectory()
         if self.directory:
             self.image_files = list_images_in_directory(self.directory)
@@ -190,7 +276,7 @@ class MainFunc(QMainWindow):
         self.labels = []
         self.clicked_save = []
         self.paint_save = []
-        self.ui.listWidget.clear()
+        self.clear_label_list()
 
         if not self.save_path or not self.image_name:
             return
@@ -207,9 +293,11 @@ class MainFunc(QMainWindow):
                 if not labels:
                     continue
                 self.labels = labels
-                self.paint_save = boxes
-                for name in names:
+                normalized_boxes = [self._normalized_box(box[0], box[1], box[2], box[3]) for box in boxes]
+                self.paint_save = normalized_boxes.copy()
+                for box, name in zip(normalized_boxes, names):
                     self.ui.listWidget.addItem(name)
+                    self.label_boxes_by_row.append(box)
                 self.Show_Exists()
                 return
             else:
@@ -218,9 +306,11 @@ class MainFunc(QMainWindow):
                     continue
                 self.labels = get_labels(str(xml_path))
                 self.list_labels, list_box = list_label(str(xml_path))
-                self.paint_save = list_box
-                for label in self.list_labels:
+                normalized_boxes = [self._normalized_box(box[0], box[1], box[2], box[3]) for box in list_box]
+                self.paint_save = normalized_boxes.copy()
+                for label, box in zip(self.list_labels, normalized_boxes):
                     self.ui.listWidget.addItem(label)
+                    self.label_boxes_by_row.append(box)
                 self.Show_Exists()
                 return
 
@@ -252,7 +342,7 @@ class MainFunc(QMainWindow):
         self.labels = []
         self.paint_save = []
         self.clicked_save = []
-        self.ui.listWidget.clear()
+        self.clear_label_list()
         self.show_path_image()
 
     def set_save_path(self):
@@ -334,32 +424,12 @@ class MainFunc(QMainWindow):
                         self.ui.label_4.mousePressEvent = self.mouse_press_event
                         self.ui.label_4.setCursor(Qt.ArrowCursor)
 
-                
-
-            if (event.key() == 16777219):
-                    self.clicked_event = False
-                    self.paint_event = False
-                    self.save = True
-                    self.ui.listWidget.clear()
-                    self.list_labels = []
-                    self.clicked_save = []
-                    self.paint_save = []
-                    self.show_qt(self.img_path)
-                    self.ui.label_4.mousePressEvent = self.mouse_press_event
-                    self.ui.label_4.setCursor(Qt.ArrowCursor)
-                    base_path = Path(self.save_path) / self.image_name if self.save_path else None
-                    if base_path:
-                        xml_path = base_path.with_suffix(".xml")
-                        txt_path = base_path.with_suffix(".txt")
-                        if xml_path.exists():
-                            xml_path.unlink()
-                        if txt_path.exists():
-                            txt_path.unlink()
-                        self.labels = []
-                    else:
-                        super(QMainWindow, self).keyPressEvent(event)
-
-            
+            if event.key() == Qt.Key_Delete:
+                if self.remove_selected_labels():
+                    return
+                if not self.ui.listWidget.selectedIndexes():
+                    self.clear_all_annotations()
+                return
 
 
     
@@ -372,7 +442,9 @@ class MainFunc(QMainWindow):
             result, file_path, size = xml_message(self.save_path, self.image_name, self.img_width, self.img_height,
                                                   text, self.AT.x, self.AT.y, self.AT.w, self.AT.h)
             self.labels.append(result)
-            self.clicked_save.append([self.AT.x, self.AT.y, (self.AT.w + self.AT.x), (self.AT.h + self.AT.y)])
+            box = self._normalized_box(self.AT.x, self.AT.y, self.AT.w + self.AT.x, self.AT.h + self.AT.y)
+            self.clicked_save.append(box)
+            self.label_boxes_by_row.append(box)
             self.save_annotation_files(self.image_path, self.image_name, size, self.labels)
 
         elif text and self.paint_event:
@@ -383,7 +455,9 @@ class MainFunc(QMainWindow):
                                                   text, self.x0, self.y0, abs(self.x1 - self.x0),
                                                   abs(self.y1 - self.y0))
             self.labels.append(result)
-            self.paint_save.append([self.x0, self.y0, self.x1, self.y1])
+            box = self._normalized_box(self.x0, self.y0, self.x1, self.y1)
+            self.paint_save.append(box)
+            self.label_boxes_by_row.append(box)
             self.save_annotation_files(self.image_path, self.image_name, size, self.labels)
 
             self.ui.label_4.mousePressEvent = self.mouse_press_event
@@ -404,7 +478,9 @@ class MainFunc(QMainWindow):
             result, file_path, size = xml_message(self.save_path, self.image_name, self.img_width, self.img_height,
                                                     text, self.AT.x, self.AT.y, self.AT.w, self.AT.h)
             self.labels.append(result)
-            self.clicked_save.append([self.AT.x, self.AT.y, (self.AT.w + self.AT.x), (self.AT.h + self.AT.y)])
+            box = self._normalized_box(self.AT.x, self.AT.y, self.AT.w + self.AT.x, self.AT.h + self.AT.y)
+            self.clicked_save.append(box)
+            self.label_boxes_by_row.append(box)
             self.save_annotation_files(self.image_path, self.image_name, size, self.labels)
             # 启用"开始检测打标"按钮
             self.ui.pushButton_start_marking.setEnabled(True)
@@ -501,7 +577,7 @@ class MainFunc(QMainWindow):
 # ##################################################################################################
     # 获取视频
     def get_video(self):
-        self.ui.listWidget.clear()  # 清空listWidget
+        self.clear_label_list()  # 清空listWidget
         self.image_files = None
         self.img_path = None
         self.num = 0
@@ -692,7 +768,7 @@ class MainFunc(QMainWindow):
 
         output_dir = QtWidgets.QFileDialog.getExistingDirectory(self, "选择图片保存文件夹")
         self.output_dir = output_dir
-        self.ui.listWidget.clear()
+        self.clear_label_list()
         if self.video_path and self.output_dir:
             self.Change_Enable(method="MakeTag",state=False)
             self.Change_Enable(method="ShowVideo",state=False)

--- a/GUI/main.py
+++ b/GUI/main.py
@@ -26,7 +26,7 @@ class VideoProcessingThread(QThread):
 
     def __init__(self, avt, video_path, output_dir, clicks, save_path):
         super().__init__()
-        self.AVT = AnythingVideo_TW()
+        self.AVT = avt if avt is not None else AnythingVideo_TW()
         self.video_path = video_path
         self.output_dir = output_dir
         self.clicks = clicks or []
@@ -36,6 +36,14 @@ class VideoProcessingThread(QThread):
 
     def run(self):
         try:
+            self.AVT.video_segments = {}
+            self.AVT.target_points = {}
+            self.AVT.target_methods = {}
+            self.AVT.target_labels = {}
+            self.AVT.object_boxes = {}
+            self.AVT.out_obj_ids = None
+            self.AVT.out_mask_logits = None
+
             # 创建输出目录和mask子目录
             os.makedirs(self.output_dir, exist_ok=True)
             mask_dir = os.path.join(self.output_dir, "mask")
@@ -513,12 +521,30 @@ class MainFunc(QMainWindow):
             self.save_annotation_files(self.image_path, self.image_name, size, self.labels)
             # 启用"开始检测打标"按钮
             self.ui.pushButton_start_marking.setEnabled(True)
-            if self.clicked_x is not None and self.clicked_y is not None:
-                self.video_clicks.append({
-                    "coords": [self.clicked_x, self.clicked_y],
-                    "method": self.method,
+            points = [list(pt) for pt in getattr(self.AT, "coords", [])]
+            methods = list(getattr(self.AT, "methods", []))
+            if not points and self.clicked_x is not None and self.clicked_y is not None:
+                points = [[self.clicked_x, self.clicked_y]]
+            if not methods and self.method is not None:
+                methods = [self.method]
+            if points and methods:
+                click_payload = {
+                    "points": points,
+                    "methods": methods,
                     "label": text,
-                })
+                }
+                if self.clicked_x is not None and self.clicked_y is not None:
+                    click_payload["coords"] = [self.clicked_x, self.clicked_y]
+                if self.method is not None:
+                    click_payload["method"] = self.method
+                self.video_clicks.append(click_payload)
+
+            self.AT.coords = []
+            self.AT.methods = []
+            self.AT.option = False
+            self.clicked_x = None
+            self.clicked_y = None
+            self.method = None
         # 重新启用点击事件，允许继续添加下一个目标
         if self.is_video_mode:
             self.ui.label_4.mousePressEvent = self.mouse_press_event

--- a/GUI/main.py
+++ b/GUI/main.py
@@ -519,6 +519,10 @@ class MainFunc(QMainWindow):
                     "method": self.method,
                     "label": text,
                 })
+        # 重新启用点击事件，允许继续添加下一个目标
+        if self.is_video_mode:
+            self.ui.label_4.mousePressEvent = self.mouse_press_event
+            self.ui.label_4.setCursor(Qt.ArrowCursor)
         self.clicked_event = False
         self.paint_event = False
 

--- a/GUI/main.py
+++ b/GUI/main.py
@@ -24,21 +24,17 @@ class VideoProcessingThread(QThread):
     finished = pyqtSignal()  # 完成信号
     frame_ready = pyqtSignal(object)  # 添加新信号用于传递处理后的帧
 
-    def __init__(self, avt, video_path, output_dir,clicked_x, clicked_y, method,text,save_path):
+    def __init__(self, avt, video_path, output_dir, clicks, save_path):
         super().__init__()
         self.AVT = AnythingVideo_TW()
         self.video_path = video_path
         self.output_dir = output_dir
-        self.clicked_x = clicked_x
-        self.clicked_y = clicked_y
-        self.method = method
-        self.text = text
+        self.clicks = clicks or []
         self.save_path = save_path
         self.xml_messages = []
         os.makedirs(self.output_dir, exist_ok=True)
 
     def run(self):
-        print(self.clicked_x, self.clicked_y, self.method)
         try:
             # 创建输出目录和mask子目录
             os.makedirs(self.output_dir, exist_ok=True)
@@ -49,11 +45,32 @@ class VideoProcessingThread(QThread):
             self.AVT.extract_frames_from_video(self.video_path, self.output_dir,fps=2)
             self.AVT.set_video(self.output_dir)
             self.AVT.inference(self.output_dir)
-            self.AVT.Set_Clicked([self.clicked_x, self.clicked_y], self.method)
-            self.AVT.add_new_points_or_box()
-            
+            for obj_id, click in enumerate(self.clicks, start=1):
+                points = click.get("points")
+                if not points:
+                    coord = click.get("coords") or []
+                    if coord:
+                        points = [coord]
+                if not points:
+                    continue
+                methods = click.get("methods")
+                if not methods:
+                    method = click.get("method")
+                    if method is not None:
+                        methods = [method]
+                class_name = click.get("label") or click.get("text") or f"obj_{obj_id}"
+                self.AVT.add_new_points_or_box(
+                    obj_id=obj_id,
+                    points=points,
+                    labels=methods,
+                    class_name=class_name,
+                )
+
             # 获取处理后的帧并发送信号
-            processed_frame, xml_messages = self.AVT.Draw_Mask_at_frame(save_image_path=mask_dir,save_path=self.save_path,text=self.text)  # 使用新的mask_dir路径
+            processed_frame, xml_messages = self.AVT.Draw_Mask_at_frame(
+                save_image_path=mask_dir,
+                save_path=self.save_path,
+            )  # 使用新的mask_dir路径
             self.xml_messages = xml_messages
             self.frame_ready.emit(processed_frame)  # 发送处理后的帧
             
@@ -87,6 +104,8 @@ class MainFunc(QMainWindow):
         self.paint_save = []
         self.label_boxes_by_row = []
         self.list_labels = []
+        self.video_clicks = []
+        self.is_video_mode = False
         self.flag = False
         self.save = True
         self.cap = None
@@ -204,10 +223,15 @@ class MainFunc(QMainWindow):
                 box = self.label_boxes_by_row.pop(row)
                 self._remove_box_from_collections(box)
 
+            if self.is_video_mode and row < len(self.video_clicks):
+                self.video_clicks.pop(row)
+
         if removed:
             if self.img_path:
                 self.Show_Exists()
             self._persist_labels_after_edit()
+            if self.is_video_mode and not self.video_clicks:
+                self.ui.pushButton_start_marking.setEnabled(False)
 
         return removed
 
@@ -220,6 +244,9 @@ class MainFunc(QMainWindow):
         self.clicked_save = []
         self.paint_save = []
         self.labels = []
+        self.video_clicks = []
+        if self.is_video_mode:
+            self.ui.pushButton_start_marking.setEnabled(False)
         if self.img_path:
             self.show_qt(self.img_path)
         self.ui.label_4.mousePressEvent = self.mouse_press_event
@@ -239,6 +266,8 @@ class MainFunc(QMainWindow):
         if self.cap:
             self.timer_camera.stop()
             self.clear_label_list()  # 清空listWidget
+        self.is_video_mode = False
+        self.video_clicks = []
         self.directory = QtWidgets.QFileDialog.getExistingDirectory()
         if self.directory:
             self.image_files = list_images_in_directory(self.directory)
@@ -484,6 +513,12 @@ class MainFunc(QMainWindow):
             self.save_annotation_files(self.image_path, self.image_name, size, self.labels)
             # 启用"开始检测打标"按钮
             self.ui.pushButton_start_marking.setEnabled(True)
+            if self.clicked_x is not None and self.clicked_y is not None:
+                self.video_clicks.append({
+                    "coords": [self.clicked_x, self.clicked_y],
+                    "method": self.method,
+                    "label": text,
+                })
         self.clicked_event = False
         self.paint_event = False
 
@@ -762,6 +797,8 @@ class MainFunc(QMainWindow):
             upWindowsh("请先选择视频和保存路径")
 
     def video_marking(self):
+        self.is_video_mode = True
+        self.video_clicks = []
         self.directory = None
         video_path, _ = QtWidgets.QFileDialog.getOpenFileName(self, "选择视频", "", "Video Files (*.mp4 *.mpg)")
         self.video_path = video_path
@@ -769,6 +806,7 @@ class MainFunc(QMainWindow):
         output_dir = QtWidgets.QFileDialog.getExistingDirectory(self, "选择图片保存文件夹")
         self.output_dir = output_dir
         self.clear_label_list()
+        self.ui.pushButton_start_marking.setEnabled(False)
         if self.video_path and self.output_dir:
             self.Change_Enable(method="MakeTag",state=False)
             self.Change_Enable(method="ShowVideo",state=False)
@@ -806,35 +844,46 @@ class MainFunc(QMainWindow):
             # 鼠标点击触发
             self.ui.label_4.mousePressEvent = self.mouse_press_event
         else:
+            self.is_video_mode = False
+            self.video_clicks = []
             upWindowsh("请先选择视频和保存路径")
 
 
     def on_video_processing_complete(self):
         self.worker_thread.deleteLater()
         self.xml_messages = self.worker_thread.xml_messages
-        # print(self.xml_messages)
-        
-        # 遍历输出目录中的图片
+        frame_messages = {}
+        for message in self.xml_messages or []:
+            frame_name = message.get("frame_name")
+            if not frame_name:
+                continue
+            frame_messages[frame_name] = message
+
         for img_file in os.listdir(self.output_dir):
-            if img_file.endswith(('.jpg', '.jpeg', '.png')):  # 检查图片文件扩展名
-                # 获取不带扩展名的文件名
-                img_name = os.path.splitext(img_file)[0]
-                img_file  = os.path.join(self.output_dir,img_file)
+            if not img_file.lower().endswith((".jpg", ".jpeg", ".png")):
+                continue
 
-                # 在xml_messages中查找对应的消息
-                for msg in self.xml_messages:
-                    self.labels = []
-                    if len(msg) > 1:  # 确保msg有足够的元素
-                        xml_path = msg[1]  # 获取索引值为1的路径
-                        xml_filename = os.path.splitext(os.path.basename(xml_path))[0]
+            img_path = os.path.join(self.output_dir, img_file)
+            frame_stem = os.path.splitext(img_file)[0]
+            message = frame_messages.get(frame_stem)
+            if not message:
+                continue
 
-                        # 如果文件名匹配，则复制XML文件到save_path
-                        if xml_filename == img_name and self.save_path:
-                            result = msg[0]
-                            file_path = msg[1]
-                            size = msg[2]
-                            self.labels.append(result)
-                            self.save_annotation_files(img_file, img_name, size, self.labels)
+            labels = message.get("results") or []
+            if not labels:
+                continue
+
+            size = message.get("size")
+            if not size:
+                image = cv2.imread(img_path)
+                if image is not None:
+                    height, width = image.shape[:2]
+                    size = [width, height, 3]
+
+            self.save_annotation_files(img_path, frame_stem, size, labels)
+
+        if self.video_clicks:
+            self.ui.pushButton_start_marking.setEnabled(True)
         self.ui.listWidget.addItem("检测打标完成！")
         print("检测打标完成！")
 
@@ -878,11 +927,24 @@ class MainFunc(QMainWindow):
         # 禁用开始检测打标按钮
         self.ui.pushButton_start_marking.setEnabled(False)
         if self.video_path and self.output_dir:
+            if not self.video_clicks:
+                upWindowsh("请先选择目标并添加标签")
+                self.ui.pushButton_start_marking.setEnabled(bool(self.video_clicks))
+                return
+
+            clicks_payload = [dict(click) for click in self.video_clicks]
+
             # 创建并启动工作线程
-            self.worker_thread = VideoProcessingThread(self.AVT, self.video_path, self.output_dir,self.clicked_x, self.clicked_y, self.method,self.text,self.save_path)
+            self.worker_thread = VideoProcessingThread(
+                self.AVT,
+                self.video_path,
+                self.output_dir,
+                clicks_payload,
+                self.save_path,
+            )
             self.worker_thread.finished.connect(self.on_video_processing_complete)
             self.worker_thread.start()
-            
+
 
         else:
             upWindowsh("请先选择视频和保存路径")

--- a/sampro/LabelVideo_TW.py
+++ b/sampro/LabelVideo_TW.py
@@ -33,8 +33,6 @@ class AnythingVideo_TW():
         self.predictor = build_sam2_video_predictor(self.model_cfg, self.sam2_checkpoint, self.device)
 
         # 全局变量
-        self.coords = []
-        self.methods = []
         self.frame = None
 
         self.option = False
@@ -46,6 +44,10 @@ class AnythingVideo_TW():
         self.out_obj_ids = None
         self.out_mask_logits = None
         self.video_segments = {}
+        self.target_points = {}
+        self.target_methods = {}
+        self.target_labels = {}
+        self.object_boxes = {}
 
         # 矩形框
         self.x = 0
@@ -161,23 +163,25 @@ class AnythingVideo_TW():
         elif label == 0:
             cv2.circle(image, (self.clicked_x, self.clicked_y), 5, (0, 0, 255), -1)  # 红色点
 
-    def add_new_points_or_box(self):
+    def add_new_points_or_box(self, obj_id, points, labels, class_name):
+        if not points or not labels:
+            return
+
         ann_frame_idx = 0  # 当前帧的索引
-        ann_obj_id = 1  # 默认目标 ID
 
-        self.coords.append([self.clicked_x, self.clicked_y])
-        self.methods.append(self.method)
-
-        points = np.array(self.coords)
-        labels = np.array(self.methods)
+        points_array = np.array(points, dtype=np.float32)
+        labels_array = np.array(labels, dtype=np.int32)
 
         _, self.out_obj_ids, self.out_mask_logits = self.predictor.add_new_points_or_box(
             inference_state=self.inference_state,
             frame_idx=ann_frame_idx,
-            obj_id=ann_obj_id,
-            points=points,
-            labels=labels,
+            obj_id=obj_id,
+            points=points_array,
+            labels=labels_array,
         )
+        self.target_points[obj_id] = points_array
+        self.target_methods[obj_id] = labels_array
+        self.target_labels[obj_id] = class_name
         self.option = True
         
 
@@ -260,14 +264,20 @@ class AnythingVideo_TW():
                 max_area = area
                 max_contour = contour
                 
+        if max_contour is None:
+            return img, None
+
         # 使用矩形框绘制最大轮廓
-        self.x, self.y, self.w, self.h = cv2.boundingRect(max_contour)
-        cv2.rectangle(img, (self.x, self.y), (self.x + self.w, self.y + self.h), (0, 255, 0), 2)
+        x, y, w, h = cv2.boundingRect(max_contour)
+        cv2.rectangle(img, (x, y), (x + w, y + h), (0, 255, 0), 2)
         # 在原图上绘制边缘线
         cv2.drawContours(img, contours, -1, (0, 255, 0), 2)
         self.image_mask = img
+        self.x, self.y, self.w, self.h = x, y, w, h
+        if obj_id is not None:
+            self.object_boxes[obj_id] = (x, y, w, h)
         print(self.x, self.y, self.w, self.h)
-        return img,self.x, self.y, self.w, self.h
+        return img, (x, y, w, h)
 
     def Draw_Mask_Video(self, output_video_path="segmented_output.mp4"):
         # 收集所有帧的分割结果
@@ -346,16 +356,15 @@ class AnythingVideo_TW():
 
 
 
-    def Draw_Mask_at_frame(self, start_frame=0, return_frames=False, save_image_path=None ,save_path=None, text=None):
+    def Draw_Mask_at_frame(self, start_frame=0, return_frames=False, save_image_path=None ,save_path=None):
         """
         遍历所有帧并绘制轮廓
         Args:
             start_frame (int): 起始帧序号
             return_frames (bool): 是否返回处理后的帧列表
             save_path (str): 保存路径
-            text (str): XML文本说明
         Returns:
-            tuple: (processed_frames, result, file_path, size) - processed_frames 在 return_frames=False 时为 None
+            tuple: (processed_frames, xml_messages)
         """
         # 1. 收集所有帧的分割结果
         for out_frame_idx, out_obj_ids, out_mask_logits in self.predictor.propagate_in_video(self.inference_state):
@@ -372,67 +381,90 @@ class AnythingVideo_TW():
         frame_names.sort(key=lambda p: int(os.path.splitext(p)[0]))
 
         processed_frames = [] if return_frames else None
-        result = None
-        file_path = None
-        size = None
 
-        # 遍历所有帧
         xml_messages = []
         for frame_idx in range(start_frame, len(frame_names)):
-            frame_path = os.path.join(self.video_path, frame_names[frame_idx])
+            frame_name = frame_names[frame_idx]
+            frame_stem = Path(frame_name).stem
+            frame_path = os.path.join(self.video_path, frame_name)
             frame = cv2.imread(frame_path)
-            frame = cv2.cvtColor(frame, cv2.COLOR_BGR2RGB)
-            
-            video_label = []
-            
+            if frame is None:
+                print(f"Warning: Invalid frame at index {frame_idx}")
+                continue
+
+            frame_rgb = cv2.cvtColor(frame, cv2.COLOR_BGR2RGB)
+            annotated_frame = frame_rgb.copy()
+
+            frame_results = []
+            frame_file_path = None
+            frame_size = None
+
             if frame_idx in self.video_segments:
                 for out_obj_id, out_mask in self.video_segments[frame_idx].items():
-                    # 检查 Draw_Mask 的返回值
-                    result = self.Draw_Mask(out_mask, frame.copy(), out_obj_id)
-                    if isinstance(result, tuple) and len(result) == 5:
-                        frame, x, y, w, h = result
-                        video_label.append([x, y, w, h])
-                    else:
-                        print(f"Warning: Draw_Mask returned unexpected format at frame {frame_idx}")
+                    annotated_frame, bbox = self.Draw_Mask(out_mask, annotated_frame, out_obj_id)
+                    if not bbox:
                         continue
-            
-                    # 确保 frame 是有效的图像数组
-                    if frame is not None and isinstance(frame, np.ndarray):
-                        frame = cv2.cvtColor(frame, cv2.COLOR_RGB2BGR)
-                        
-                        if return_frames:
-                            processed_frames.append(frame)
-                            
-                        if save_image_path:
-                            # 保存前调整图片大小
-                            frame_pil = Image.fromarray(cv2.cvtColor(frame, cv2.COLOR_BGR2RGB))
-                            
-                            # 获取照片大小
-                            width, height = frame_pil.size
-                            ratio = 1300 / width
-                            width = 1300
-                            height *= ratio
-                            reduced_image = frame_pil.resize((int(width), int(height)))
-                            
-                            if height > 850:
-                                ratio = 850 / height
-                                height = 850
-                                width *= ratio
-                                reduced_image = frame_pil.resize((int(width), int(height)))
-                            
-                            # 保存调整后的图片
-                            save_path_frame = f"{save_image_path}/{frame_idx}.jpg"
-                            reduced_image.save(save_path_frame)
-                            
-                            result, file_path, size = xml_message(
-                                save_path, frame_idx, int(width), int(height),
-                                text, self.x, self.y, self.w, self.h
-                            )
-                            xml_messages.append([result, file_path, size])
-            else:
-                print(f"Warning: Invalid frame at index {frame_idx}")
 
-        # 始终返回元组，而不是在 return_frames=False 时返回 None
+                    x, y, w, h = bbox
+                    class_name = self.target_labels.get(out_obj_id, f"obj_{out_obj_id}")
+
+                    if save_path:
+                        result, file_path, size = xml_message(
+                            save_path,
+                            frame_stem,
+                            int(annotated_frame.shape[1]),
+                            int(annotated_frame.shape[0]),
+                            class_name,
+                            x,
+                            y,
+                            x + w,
+                            y + h,
+                        )
+                    else:
+                        size = [int(annotated_frame.shape[1]), int(annotated_frame.shape[0]), 3]
+                        file_path = None
+                        result = {
+                            'name': class_name,
+                            'pose': 'Unspecified',
+                            'truncated': 0,
+                            'difficult': 0,
+                            'bndbox': [x, y, x + w, y + h],
+                        }
+
+                    frame_results.append(result)
+                    frame_file_path = file_path
+                    frame_size = size
+
+            annotated_bgr = cv2.cvtColor(annotated_frame, cv2.COLOR_RGB2BGR)
+
+            if return_frames and processed_frames is not None:
+                processed_frames.append(annotated_bgr.copy())
+
+            if save_image_path:
+                frame_pil = Image.fromarray(cv2.cvtColor(annotated_bgr, cv2.COLOR_BGR2RGB))
+                width, height = frame_pil.size
+                ratio = 1300 / width
+                width = 1300
+                height *= ratio
+                reduced_image = frame_pil.resize((int(width), int(height)))
+
+                if height > 850:
+                    ratio = 850 / height
+                    height = 850
+                    width *= ratio
+                    reduced_image = reduced_image.resize((int(width), int(height)))
+
+                save_path_frame = f"{save_image_path}/{frame_idx}.jpg"
+                reduced_image.save(save_path_frame)
+
+            if frame_results:
+                xml_messages.append({
+                    "frame_name": frame_stem,
+                    "file_path": frame_file_path,
+                    "size": frame_size,
+                    "results": frame_results,
+                })
+
         return processed_frames, xml_messages
 
 
@@ -447,7 +479,7 @@ if __name__ == '__main__':
     frame = AD.set_video(video_dir)
     AD.inference(video_dir)
     AD.Set_Clicked([300, 483], 1)
-    AD.add_new_points_or_box()
+    AD.add_new_points_or_box(obj_id=1, points=[[300, 483]], labels=[1], class_name="object")
     # AD.Draw_Mask_picture(frame_stride=1)
     # AD.Draw_Mask((AD.out_mask_logits[0] > 0.0).cpu().numpy(),frame) #暂时不用
     # AD.Draw_Mask_Video(output_video_path="segmented_output.mp4")


### PR DESCRIPTION
## Summary
- remove the left-hand toolbar from the main window UI
- add a File menu so existing actions remain available without the toolbar
- bind the Video marking action to the M key for quick access

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d8d0fb0f6c8329a16c0f4966e21ea9